### PR TITLE
proton: check directory access for mapped drives

### DIFF
--- a/proton
+++ b/proton
@@ -416,7 +416,7 @@ def setup_game_dir_drive():
             }
 
             for directory in drive_map.keys():
-                if os.path.exists(directory) and not is_directory_empty(directory):
+                if os.access(directory, os.R_OK) and not is_directory_empty(directory):
                     setup_dir_drive("gamedrive", drive_map[directory], directory)
         else:
             setup_dir_drive("gamedrive", "s:", try_get_game_library_dir())


### PR DESCRIPTION
Check if a directory is readable before attempting to map it.

Fixes this error:
Traceback (most recent call last):
  File ".../Steam/compatibilitytools.d/UMU-Proton-9.0-4e/proton", line 1930, in <module>
    g_session.init_session(sys.argv[1] != "runinprefix")
  File ".../Steam/compatibilitytools.d/UMU-Proton-9.0-4e/proton", line 1822, in init_session
    g_compatdata.setup_prefix()
  File ".../Steam/compatibilitytools.d/UMU-Proton-9.0-4e/proton", line 1204, in setup_prefix
    setup_game_dir_drive()
  File ".../Steam/compatibilitytools.d/UMU-Proton-9.0-4e/proton", line 419, in setup_game_dir_drive
    if os.path.exists(directory) and not is_directory_empty(directory):
  File ".../Steam/compatibilitytools.d/UMU-Proton-9.0-4e/proton", line 407, in is_directory_empty
    return not any(os.scandir(dir_path))
PermissionError: [Errno 13] Permission denied: '/media'

Like when running in a sandbox:
$ firejail --disable-mnt
$ ls /mnt
ls: cannot open directory '/mnt': Permission denied